### PR TITLE
fix: remove globalThis usage

### DIFF
--- a/packages/starlight-giscus/components/Comments.astro
+++ b/packages/starlight-giscus/components/Comments.astro
@@ -1,4 +1,5 @@
 ---
+import config from "virtual:starlight-giscus-config";
 const { entry, lang } = Astro.locals.starlightRoute;
 const {
     repo,
@@ -10,7 +11,7 @@ const {
     inputPosition,
     theme,
     lazy
-} = globalThis.giscusConfig;
+} = config;
 const preparedTheme = typeof theme === 'object' ? theme : { auto: theme };
 const giscus = entry.data.giscus ?? true;
 ---

--- a/packages/starlight-giscus/index.ts
+++ b/packages/starlight-giscus/index.ts
@@ -2,6 +2,7 @@ import type { StarlightPlugin } from "@astrojs/starlight/types";
 import { AstroError } from "astro/errors";
 import { z } from "astro/zod";
 import { vitePluginStarlightGiscusConfig } from "./libs/vite";
+import { overrideStarlightComponent } from "./libs/starlight";
 
 const themeSchema = z.union([
   z.string().default("preferred_color_scheme"),
@@ -36,13 +37,16 @@ export default function starlightGiscus(
   return {
     name: "starlight-giscus",
     hooks: {
-      "config:setup"({ config, updateConfig, addIntegration }) {
-        if (config.components?.Pagination) return;
-
+      "config:setup"({ logger, config, updateConfig, addIntegration }) {
         updateConfig({
           components: {
             ...config.components,
-            Pagination: "starlight-giscus/overrides/Pagination.astro",
+            ...overrideStarlightComponent(
+              config.components,
+              logger,
+              "Pagination",
+              "Pagination",
+            ),
           },
         });
 

--- a/packages/starlight-giscus/libs/starlight.ts
+++ b/packages/starlight-giscus/libs/starlight.ts
@@ -1,0 +1,24 @@
+import type { StarlightUserConfig } from "@astrojs/starlight/types";
+import type { AstroIntegrationLogger } from "astro";
+
+export function overrideStarlightComponent(
+  components: StarlightUserConfig["components"],
+  logger: AstroIntegrationLogger,
+  override: keyof NonNullable<StarlightUserConfig["components"]>,
+  component: string,
+) {
+  if (components?.[override]) {
+    logger.warn(
+      `It looks like you already have a \`${override}\` component override in your Starlight configuration.`,
+    );
+    logger.warn(
+      `To use \`starlight-giscus\`, either remove your override or update it to render the content from \`starlight-giscus/components/${component}.astro\`.`,
+    );
+
+    return {};
+  }
+
+  return {
+    [override]: `starlight-giscus/overrides/${override}.astro`,
+  };
+}

--- a/packages/starlight-giscus/libs/vite.ts
+++ b/packages/starlight-giscus/libs/vite.ts
@@ -1,0 +1,37 @@
+import type { ViteUserConfig } from "astro";
+
+import type { StarlightGiscusConfig } from "..";
+
+export function vitePluginStarlightGiscusConfig(
+  starlightGiscusConfig: StarlightGiscusConfig,
+): VitePlugin {
+  const modules = {
+    "virtual:starlight-giscus-config": `export default ${JSON.stringify(starlightGiscusConfig)}`,
+  };
+
+  const moduleResolutionMap = Object.fromEntries(
+    (Object.keys(modules) as (keyof typeof modules)[]).map((key) => [
+      resolveVirtualModuleId(key),
+      key,
+    ]),
+  );
+
+  return {
+    name: "vite-plugin-starlight-giscus",
+    load(id) {
+      const moduleId = moduleResolutionMap[id];
+      return moduleId ? modules[moduleId] : undefined;
+    },
+    resolveId(id) {
+      return id in modules ? resolveVirtualModuleId(id) : undefined;
+    },
+  };
+}
+
+function resolveVirtualModuleId<TModuleId extends string>(
+  id: TModuleId,
+): `\0${TModuleId}` {
+  return `\0${id}`;
+}
+
+type VitePlugin = NonNullable<ViteUserConfig["plugins"]>[number];

--- a/packages/starlight-giscus/virtual.d.ts
+++ b/packages/starlight-giscus/virtual.d.ts
@@ -1,0 +1,4 @@
+declare module "virtual:starlight-giscus-config" {
+  const StarlightGiscusConfig: import("./index").StarlightGiscusConfig;
+  export default StarlightGiscusConfig;
+}


### PR DESCRIPTION
#### Description

I ran into the problem that I want to include the plugin dynamically depending on if I have the `.env` variables set or not. Unfortunately, this does not work as this plugin uses `globalThis` which tries to load the necessary user config when importing and not dynamically with a virtual module.

So I created these changes to not include the `globalThis` keyword but instead create a virtual module when the plugin gets added via `addIntegration`, `updateConfig` and the vite option. All configuration options are then available in the `Comments.astro` component like before but by using the imported virtual module `config` object now.

My prettier formatter made all `'` to `"` that's why it looks like more changes than it is.

I do not know how you handle release, I recommend setting up something like the https://github.com/changesets/action which works pretty good for such monorepos 👍 